### PR TITLE
Fix platform; volume name mistake

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -13,7 +13,7 @@
 define(NERVES_FW_PRODUCT, "Nerves Firmware")
 define(NERVES_FW_DESCRIPTION, "")
 define(NERVES_FW_VERSION, "${NERVES_SDK_VERSION}")
-define(NERVES_FW_PLATFORM, "rpi")
+define(NERVES_FW_PLATFORM, "rpi0")
 define(NERVES_FW_ARCHITECTURE, "arm")
 define(NERVES_FW_AUTHOR, "The Nerves Team")
 
@@ -302,7 +302,7 @@ task upgrade.b {
 
         # Reset the previous contents of the B boot partition
         fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})
-        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-B")
+        fat_setlabel(${BOOT_B_PART_OFFSET}, "BOOT-B")
         fat_mkdir(${BOOT_B_PART_OFFSET}, "overlays")
     }
 


### PR DESCRIPTION
The platform is now "rpi0" to differentiate it from "rpi".