### PR TITLE
fwup.conf updates

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -84,6 +84,8 @@ meta-version = ${NERVES_FW_VERSION}
 meta-platform = ${NERVES_FW_PLATFORM}
 meta-architecture = ${NERVES_FW_ARCHITECTURE}
 meta-author = ${NERVES_FW_AUTHOR}
+meta-vcs-identifier = ${NERVES_FW_VCS_IDENTIFIER}
+meta-misc = ${NERVES_FW_MISC}
 
 # File resources are listed in the order that they are included in the .fw file
 # This is important, since this is the order that they're written on a firmware
@@ -197,6 +199,8 @@ task complete {
         uboot_setenv(uboot-env, "a.nerves_fw_platform", ${NERVES_FW_PLATFORM})
         uboot_setenv(uboot-env, "a.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
         uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
 
         fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
         fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
@@ -282,6 +286,8 @@ task upgrade.a {
         uboot_setenv(uboot-env, "a.nerves_fw_platform", ${NERVES_FW_PLATFORM})
         uboot_setenv(uboot-env, "a.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
         uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
 
 	# Switch over to boot the new firmware
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
@@ -338,6 +344,8 @@ task upgrade.b {
         uboot_setenv(uboot-env, "b.nerves_fw_platform", ${NERVES_FW_PLATFORM})
         uboot_setenv(uboot-env, "b.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
         uboot_setenv(uboot-env, "b.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "b.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "b.nerves_fw_misc", ${NERVES_FW_MISC})
 
 	# Switch over to boot the new firmware
         uboot_setenv(uboot-env, "nerves_fw_active", "b")

--- a/fwup.conf
+++ b/fwup.conf
@@ -243,6 +243,10 @@ task upgrade.a {
     # This task upgrades the A partition
     require-partition-offset(1, ${ROOTFS_B_PART_OFFSET})
 
+    # Verify the expected platform/architecture
+    require-uboot-variable(uboot-env, "b.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "b.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+
     on-init {
         info("Upgrading the A partition")
 
@@ -302,6 +306,10 @@ task upgrade.b {
     # This task upgrades the B partition
     require-partition-offset(1, ${ROOTFS_A_PART_OFFSET})
 
+    # Verify the expected platform/architecture
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+
     on-init {
         info("Upgrading the B partition")
 
@@ -357,7 +365,15 @@ task upgrade.b {
 }
 
 task upgrade.unexpected {
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
     on-init {
         error("Please check the media being upgraded. It doesn't look like either the A or B partitions are active.")
+    }
+}
+
+task upgrade.wrongplatform {
+    on-init {
+        error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
     }
 }

--- a/fwup.conf
+++ b/fwup.conf
@@ -252,7 +252,7 @@ task upgrade.a {
 
         # Clear some firmware information just in case this update gets
         # interrupted midway.
-        uboot_unsetenv(uboot-env, "nerves_fw_a_version")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_version")
 
         # Reset the previous contents of the A boot partition
         fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
@@ -315,7 +315,7 @@ task upgrade.b {
 
         # Clear some firmware information just in case this update gets
         # interrupted midway.
-        uboot_unsetenv(uboot-env, "nerves_fw_b_version")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_version")
 
         # Reset the previous contents of the B boot partition
         fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})

--- a/fwup.conf
+++ b/fwup.conf
@@ -250,6 +250,9 @@ task upgrade.a {
         fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
         fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
         fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
+
+        # Indicate that the entire partition can be cleared
+        trim(${ROOTFS_A_PART_OFFSET}, ${ROOTFS_A_PART_COUNT})
     }
 
     # Write the new boot partition files and rootfs. The MBR still points
@@ -304,6 +307,8 @@ task upgrade.b {
         fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})
         fat_setlabel(${BOOT_B_PART_OFFSET}, "BOOT-B")
         fat_mkdir(${BOOT_B_PART_OFFSET}, "overlays")
+
+        trim(${ROOTFS_B_PART_OFFSET}, ${ROOTFS_B_PART_COUNT})
     }
 
     # Write the new boot partition files and rootfs. The MBR still points

--- a/fwup.conf
+++ b/fwup.conf
@@ -44,7 +44,7 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # +----------------------------+
 # | p1*: Rootfs B (squashfs)   |
 # +----------------------------+
-# | p2: Application (ext4)    |
+# | p2: Application (ext4)     |
 # +----------------------------+
 #
 # The p0/p1 partition points to whichever of configurations A or B that is

--- a/rootfs-additions/etc/fw_env.config
+++ b/rootfs-additions/etc/fw_env.config
@@ -1,6 +1,6 @@
 # fw_printenv and fw_setenv configuration
 #
-# This is only used for storing firmware metadata on this platform.  I.e. you
+# This is only used for storing firmware metadata on this platform. I.e. you
 # don't need to use the U-Boot bootloader if you're not already using it.
 #
 # See fwup.conf for offset and size


### PR DESCRIPTION
This PR has the following updates:

1. Trim rootfs - saves a read/modify/write operation on each update
2. Adds meta-misc and meta-vcs-identifier
3. Checks platform and architecture before updating

See individual commits for more information.

Note that the platform/architecture checks are not backwards compatible with v0.15.0. This is because the platform used to be set as `rpi` instead of `rpi0`. I changed that a couple weeks ago, but a release hasn't gone out with that change.