### PR TITLE
Mount configfs on boot

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -49,6 +49,7 @@
 #       initializing any expected files and folders.
 -m /dev/mmcblk0p1:/boot:vfat:ro,nodev,noexec,nosuid:
 -m /dev/mmcblk0p3:/root:ext4:nodev:
+-m configfs:/sys/kernel/config:configfs:nodev,noexec,nosuid:
 
 # Erlang release search path
 -r /srv/erlang


### PR DESCRIPTION
It was always available and mounting it in erlinit saves having to mount
it later. This will be useful for people experimenting with device tree
overlays and USB gadget mode settings.