### PR TITLE
Add ramoops.dts to hex project

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -86,6 +86,7 @@ defmodule NervesSystemRpi0.MixProject do
       "nerves_defconfig",
       "post-build.sh",
       "post-createfs.sh",
+      "ramoops.dts",
       "README.md",
       "VERSION"
     ]


### PR DESCRIPTION
This was missing from the (luckily unpublished) release.