### PR TITLE
Use nbtty to poll ttyGS0 until it exists

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -5,16 +5,16 @@
 
 # Specify where erlinit should send the IEx prompt. Only one may be enabled at
 # a time.
--c ttyGS0      # Virtual serial port over the USB interface
-# -c ttyAMA0   # UART pins on the GPIO connector
+-c null        # Nowhere - let nbtty send it to the gadget USB serial port
 # -c tty1      # HDMI output
 
 # If more than one tty are available, always warn if the user is looking at the
 # wrong one.
 --warn-unused-tty
 
-# Use nbtty to improve terminal handling on serial ports. It's a noop on HDMI.
--s "/usr/bin/nbtty"
+# Use nbtty to improve terminal handling on serial ports.
+# Change this to ttyAMA0 to use the UART pins and remove for HDMI
+-s "/usr/bin/nbtty --tty /dev/ttyGS0 --wait-input"
 
 # Specify the user and group IDs for the Erlang VM
 #--uid 100


### PR DESCRIPTION
Since moving more drivers to modules while trying to address the USB
gadget issues, `/dev/ttyGS0` stopped being created on init. This fixes
the issue by moving the call to open the device to `nbtty` which can
poll until it has been created.

It is worthwhile to note that it appears that on the Raspberry Pi that
if you do not have anything reading from `/dev/ttyGS0`, that a Linux PC
connected over the gadget interface will lose the ability to do any USB
operations to the device if it does anything with the serial port. Many
Linux distros start ModemManager which connects to any serial port when
its detected. This was enough to hang the USB connection nearly every
time. The switch to using `nbtty` fixes this issue as well.