### PR TITLE
Comment out pi3-miniuart-bt to facilitate UART to BT module comms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## vNEXT
+
+* Enhancements
+  * UART communication with the Bluetooth module works by default on `ttyAMA0`
+
 ## v1.7.2
 
 * Bux fixes

--- a/config.txt
+++ b/config.txt
@@ -36,7 +36,7 @@ dtoverlay=ramoops
 
 # Enable the UART (/dev/ttyAMA0) on the RPi0.
 enable_uart=1
-dtoverlay=pi3-miniuart-bt
+#dtoverlay=pi3-miniuart-bt
 
 # The active LED is active low instead of active high like other Raspberry Pis
 dtparam=act_led_activelow=on


### PR DESCRIPTION
Posted this in `#nervesbluetooth` with respect to using [Harald](https://github.com/verypossible/harald) on a RPI0W:

> The only change that would need to happen to the `nerves_system_rpi0` would be to the `config.txt`, either:
> - comment out `dtoverlay=pi3-miniuart-bt`
> - add `core_freq=250`
> I would vote for the former, the reasoning is explained in detail here: https://www.raspberrypi.org/documentation/configuration/uart.md 