### PR TITLE
Mount the cgroup special directories

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -51,6 +51,9 @@
 -m /dev/mmcblk0p3:/root:ext4:nodev:
 -m configfs:/sys/kernel/config:configfs:nodev,noexec,nosuid:
 -m pstore:/sys/fs/pstore:pstore:nodev,noexec,nosuid:
+-m tmpfs:/sys/fs/cgroup:tmpfs:nodev,noexec,nosuid:mode=755,size=1024k
+-m cpu:/sys/fs/cgroup/cpu:cgroup:nodev,noexec,nosuid:cpu
+-m memory:/sys/fs/cgroup/memory:cgroup:nodev,noexec,nosuid:memory
 
 # Erlang release search path
 -r /srv/erlang


### PR DESCRIPTION
These directories have been mountable for a long time. This makes it
much easier to use them.