### PR TITLE
Set expand=true on application partition

### DIFF
--- a/fwup-revert.conf
+++ b/fwup-revert.conf
@@ -116,6 +116,7 @@ mbr mbr-a {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
+        expand = true
     }
     # partition 3 is unused
 }
@@ -136,6 +137,7 @@ mbr mbr-b {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
+        expand = true
     }
     # partition 3 is unused
 }

--- a/fwup.conf
+++ b/fwup.conf
@@ -153,6 +153,7 @@ mbr mbr-a {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
+        expand = true
     }
     # partition 3 is unused
 }
@@ -173,6 +174,7 @@ mbr mbr-b {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
+        expand = true
     }
     # partition 3 is unused
 }


### PR DESCRIPTION
This enlarges the application partition to fill the destination when
programming MicroSD, etc. for the first time. Users wanting to enlarge
application partitions in devices in the field will need to do more work
since fwup doesn't know how to expand filesystem data structures.

Devices with fwup versions before 1.3.0 (Feb 2019) will ignore the
expand flag.