### PR TITLE
Force nerves ~> 1.7.3 to fix download issue

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule NervesSystemRpi0.MixProject do
 
   defp deps do
     [
-      {:nerves, "~> 1.5.4 or ~> 1.6.0 or ~> 1.7.0", runtime: false},
+      {:nerves, "~> 1.5.4 or ~> 1.6.0 or ~> 1.7.3", runtime: false},
       {:nerves_system_br, "1.14.3", runtime: false},
       {:nerves_toolchain_armv6_nerves_linux_gnueabihf, "~> 1.4.1", runtime: false},
       {:nerves_system_linter, "~> 0.4", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
This will force anyone who hasn't upgraded to nerves 1.7.3 to update so
that they don't hit the download issue.