### PR TITLE
Fix link to firmware customisation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ for more information.
 
 If you need custom modifications to this system for your device, clone this
 repository and update as described in [Making custom
-systems](https://hexdocs.pm/nerves/systems.html#customizing-your-own-nerves-system)
+systems](https://hexdocs.pm/nerves/customizing-systems.html)
 
 ## USB OTG support
 


### PR DESCRIPTION
This is a very minor cleanup. 

The previous link was valid, but led to a notice saying the docs had been moved. This commit updates the link to the new location.