### PR TITLE
Enable Bluetooth support: add core_freq setting

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -37,6 +37,7 @@ dtoverlay=ramoops
 # Enable the UART (/dev/ttyAMA0) on the RPi0.
 enable_uart=1
 dtoverlay=miniuart-bt
+core_freq=250
 
 # The active LED is active low instead of active high like other Raspberry Pis
 dtparam=act_led_activelow=on


### PR DESCRIPTION
When struggling to get bluetooth to work using [blue_heron](https://github.com/blue-heron/blue_heron), I came found this inside the [raspberry pi docs](https://www.raspberrypi.org/documentation/configuration/uart.md):

> miniuart-bt switches the Bluetooth function to use the mini UART, and makes the first PL011 (UART0) the primary UART. Note that this may reduce the maximum usable baud rate (see mini UART limitations below). You must also set the VPU core clock to a fixed frequency using either force_turbo=1 or core_freq=250.

After adding `core_freq=250` to my projects `config.txt`, everything worked like a charm.