### PR TITLE
build-tools 0.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ exec: &exec
 version: 2.1
 
 orbs:
-  build-tools: nerves-project/build-tools@0.2.1
+  build-tools: nerves-project/build-tools@0.2.2
 
 workflows:
   version: 2
@@ -16,7 +16,6 @@ workflows:
           exec:
             <<: *exec
           context: org-global
-          push-to-download-site: true
       - build-tools/build-system:
           exec:
             <<: *exec


### PR DESCRIPTION
Changes the `push-to-download-site` to an env var so that the
system can more easily be copied to other repos.

This is set in the `org-global` context of `nerves-project`
CircleCI settings to keep behavior working as is