### PR TITLE
Update HexDoc URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,7 @@ This is a Buildroot version update that appears to mostly contain bug and
 security fixes. It should be a low risk upgrade from v1.23.2.
 
 * New features
-  * Support factory reset, preventing firmware reverts. See [Nerves.Runtime.FwupOps](https://hexdocs.pm/nerves_runtime/Nerves.Runtime.FwupOps.html)
+  * Support factory reset, preventing firmware reverts. See [Nerves.Runtime.FwupOps](https://nerves-runtime.hexdocs.pm/Nerves.Runtime.FwupOps.html)
 
 * Updated dependencies
   * [nerves_system_br v1.24.0](https://github.com/nerves-project/nerves_system_br/releases/tag/v1.24.0)
@@ -766,7 +766,7 @@ This release updates to [Buildroot
 
 * New features
   * Added support for updating the root filesystem using firmware patches.
-    See the [firmware patch docs](https://hexdocs.pm/nerves/experimental-features.html#content) for more information.
+    See the [firmware patch docs](https://nerves.hexdocs.pm/experimental-features.html#content) for more information.
 
 ## v1.12.2
 
@@ -855,7 +855,7 @@ on the GPIO header. The gadget driver has been changed to use g_ether. This
 provides a more stable network connection at the expense of the virtual serial
 port. Console access has been output to the UART. If you were using the UART
 to connect to peripherals, you will need to disable the console.
-See: https://hexdocs.pm/nerves/advanced-configuration.html#overwriting-files-in-the-boot-partition
+See: https://nerves.hexdocs.pm/advanced-configuration.html#overwriting-files-in-the-boot-partition
 for more information.
 
 * Enhancements
@@ -1193,7 +1193,7 @@ can re-enable prints by updating the cmdline.txt. See README.md.
   * Automount the boot partition readonly at `/boot`
   * Support for reverting firmware.
 
-    See [Reverting Firmware](https://hexdocs.pm/nerves_runtime/readme.html#reverting-firmware) for more info on reverting firmware.
+    See [Reverting Firmware](https://nerves-runtime.hexdocs.pm/readme.html#reverting-firmware) for more info on reverting firmware.
 
     See [fwup-revert.conf](https://github.com/nerves-project/nerves_system_rpi/blob/master/fwup-revert.conf) for more information on how fwup handles reverting.
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ appropriate for your setup.
 
 The most common way of using this Nerves System is create a project with `mix
 nerves.new` and to export `MIX_TARGET=rpi0`. See the [Getting started
-guide](https://hexdocs.pm/nerves/getting-started.html#creating-a-new-nerves-app)
+guide](https://nerves.hexdocs.pm/getting-started.html#creating-a-new-nerves-app)
 for more information.
 
 If you need custom modifications to this system for your device, clone this
 repository and update as described in [Making custom
-systems](https://hexdocs.pm/nerves/customizing-systems.html).
+systems](https://nerves.hexdocs.pm/customizing-systems.html).
 
 ## Upgrading to 2.0
 
@@ -62,7 +62,7 @@ If you don't do this, the device will run the old firmware on the next reboot.
 A simple default way of validating the firmware can be enabled using
 Nerves.Runtime's startup guard feature as described in [Assisted firmware
 validation and automatic
-revert](https://hexdocs.pm/nerves_runtime/readme.html#assisted-firmware-validation-and-automatic-revert).
+revert](https://nerves-runtime.hexdocs.pm/readme.html#assisted-firmware-validation-and-automatic-revert).
 Please follow the directions there for the needed config file update.
 
 If in doubt, use `mix nerves.new` to create a new project and compare what it
@@ -143,7 +143,7 @@ outside of any filesystem. Provisioning is an optional step and reasonable
 defaults are provided if this is missing.
 
 Provisioning information can be queried using the Nerves.Runtime KV store's
-[`Nerves.Runtime.KV.get/1`](https://hexdocs.pm/nerves_runtime/Nerves.Runtime.KV.html#get/1)
+[`Nerves.Runtime.KV.get/1`](https://nerves-runtime.hexdocs.pm/Nerves.Runtime.KV.html#get/1)
 function.
 
 Keys used by this system are:


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-runtime.hexdocs.pm/Nerves.Runtime.FwupOps.html): Status 404
❌ Verification failed for https://nerves.hexdocs.pm/getting-started.html#creating-a-new-nerves-app): %Req.HTTPError{protocol: :http2, reason: :pool_not_available}
❌ Verification failed for https://nerves.hexdocs.pm/customizing-systems.html): Status 301
⚠️ Verification finished: 5 success, 3 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>